### PR TITLE
fix: サイドバーとヘッダーの重複表示を修正

### DIFF
--- a/src/app/analytics/page.tsx
+++ b/src/app/analytics/page.tsx
@@ -1,51 +1,41 @@
 import { Suspense } from 'react'
-import { Sidebar } from '@/components/layout/sidebar'
-import { Header } from '@/components/layout/header'
 
 export default function AnalyticsPage() {
   return (
-    <div className="flex min-h-screen bg-gray-50">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 lg:pl-64">
-          <div className="px-4 py-6 sm:px-6 lg:px-8">
-            <div className="sm:flex sm:items-center">
-              <div className="sm:flex-auto">
-                <h1 className="text-2xl font-semibold text-gray-900">分析・レポート</h1>
-                <p className="mt-2 text-sm text-gray-700">
-                  AI活用の効果測定とマッチング精度の分析データをご確認いただけます
-                </p>
-              </div>
-              <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-                <button
-                  type="button"
-                  className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  レポート出力
-                </button>
-              </div>
-            </div>
+    <div className="px-4 py-6 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-gray-900">分析・レポート</h1>
+          <p className="mt-2 text-sm text-gray-700">
+            AI活用の効果測定とマッチング精度の分析データをご確認いただけます
+          </p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <button
+            type="button"
+            className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            レポート出力
+          </button>
+        </div>
+      </div>
 
-            {/* 分析機能は開発中メッセージ */}
-            <div className="mt-6">
-              <div className="bg-white shadow rounded-lg p-6">
-                <div className="text-center py-12">
-                  <div className="mx-auto h-12 w-12 text-gray-400">
-                    <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
-                    </svg>
-                  </div>
-                  <h3 className="mt-2 text-sm font-medium text-gray-900">分析機能開発中</h3>
-                  <p className="mt-1 text-sm text-gray-500">
-                    詳細な分析機能は現在開発中です。<br/>
-                    基本的なAI処理とマッチング機能は正常に動作しています。
-                  </p>
-                </div>
-              </div>
+      {/* 分析機能は開発中メッセージ */}
+      <div className="mt-6">
+        <div className="bg-white shadow rounded-lg p-6">
+          <div className="text-center py-12">
+            <div className="mx-auto h-12 w-12 text-gray-400">
+              <svg fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z" />
+              </svg>
             </div>
+            <h3 className="mt-2 text-sm font-medium text-gray-900">分析機能開発中</h3>
+            <p className="mt-1 text-sm text-gray-500">
+              詳細な分析機能は現在開発中です。<br/>
+              基本的なAI処理とマッチング機能は正常に動作しています。
+            </p>
           </div>
-        </main>
+        </div>
       </div>
     </div>
   )

--- a/src/app/contents/page.tsx
+++ b/src/app/contents/page.tsx
@@ -1,49 +1,39 @@
 import { Suspense } from 'react'
-import { Sidebar } from '@/components/layout/sidebar'
-import { Header } from '@/components/layout/header'
 import { ContentList } from '@/components/contents/content-list'
 import { ContentFilters } from '@/components/contents/content-filters'
 
 export default function ContentsPage() {
   return (
-    <div className="flex min-h-screen bg-gray-50">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 lg:pl-64">
-          <div className="px-4 py-6 sm:px-6 lg:px-8">
-            <div className="sm:flex sm:items-center">
-              <div className="sm:flex-auto">
-                <h1 className="text-2xl font-semibold text-gray-900">コンテンツ管理</h1>
-                <p className="mt-2 text-sm text-gray-700">
-                  プレスリリースやニュースコンテンツを管理し、AI機能で記者マッチングを実行できます
-                </p>
-              </div>
-              <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-                <a
-                  href="/contents/new"
-                  className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  新規コンテンツ作成
-                </a>
-              </div>
-            </div>
+    <div className="px-4 py-6 sm:px-6 lg:px-8">
+      <div className="sm:flex sm:items-center">
+        <div className="sm:flex-auto">
+          <h1 className="text-2xl font-semibold text-gray-900">コンテンツ管理</h1>
+          <p className="mt-2 text-sm text-gray-700">
+            プレスリリースやニュースコンテンツを管理し、AI機能で記者マッチングを実行できます
+          </p>
+        </div>
+        <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+          <a
+            href="/contents/new"
+            className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+          >
+            新規コンテンツ作成
+          </a>
+        </div>
+      </div>
 
-            {/* フィルター機能 */}
-            <div className="mt-6">
-              <Suspense fallback={<div>フィルターを読み込み中...</div>}>
-                <ContentFilters />
-              </Suspense>
-            </div>
+      {/* フィルター機能 */}
+      <div className="mt-6">
+        <Suspense fallback={<div>フィルターを読み込み中...</div>}>
+          <ContentFilters />
+        </Suspense>
+      </div>
 
-            {/* コンテンツ一覧 */}
-            <div className="mt-6">
-              <Suspense fallback={<div>コンテンツ一覧を読み込み中...</div>}>
-                <ContentList />
-              </Suspense>
-            </div>
-          </div>
-        </main>
+      {/* コンテンツ一覧 */}
+      <div className="mt-6">
+        <Suspense fallback={<div>コンテンツ一覧を読み込み中...</div>}>
+          <ContentList />
+        </Suspense>
       </div>
     </div>
   )

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import type { Metadata } from 'next'
 import { Inter } from 'next/font/google'
 import './globals.css'
 import { Providers } from '@/components/providers'
+import { SidebarWrapper } from '@/components/layout/sidebar-wrapper'
+import { Header } from '@/components/layout/header'
 
 const inter = Inter({ subsets: ['latin'] })
 
@@ -18,7 +20,15 @@ export default function RootLayout({
   return (
     <html lang="ja" suppressHydrationWarning>
       <body className={inter.className}>
-        <Providers>{children}</Providers>
+        <Providers>
+          <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
+            <SidebarWrapper />
+            <div className="flex-1 flex flex-col lg:pl-[min(25%,320px)]">
+              <Header />
+              {children}
+            </div>
+          </div>
+        </Providers>
       </body>
     </html>
   )

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,42 +1,34 @@
 import { Suspense } from 'react'
-import { Sidebar } from '@/components/layout/sidebar'
-import { Header } from '@/components/layout/header'
 import { DashboardStats } from '@/components/dashboard/dashboard-stats'
 import { RecommendationList } from '@/components/dashboard/recommendation-list'
 import { RecentActivity } from '@/components/dashboard/recent-activity'
 
 export default function HomePage() {
   return (
-    <div className="flex min-h-screen bg-gray-50 dark:bg-gray-900">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 p-6">
-          <div className="max-w-7xl mx-auto space-y-6">
-            <div>
-              <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
-                ダッシュボード
-              </h1>
-              <p className="text-gray-600 dark:text-gray-400 mt-2">
-                記者とコンテンツのマッチング状況を確認できます
-              </p>
-            </div>
+    <main className="flex-1 p-6">
+      <div className="max-w-7xl mx-auto space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-gray-900 dark:text-white">
+            ダッシュボード
+          </h1>
+          <p className="text-gray-600 dark:text-gray-400 mt-2">
+            記者とコンテンツのマッチング状況を確認できます
+          </p>
+        </div>
 
-            <Suspense fallback={<div>読み込み中...</div>}>
-              <DashboardStats />
-            </Suspense>
+        <Suspense fallback={<div>読み込み中...</div>}>
+          <DashboardStats />
+        </Suspense>
 
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-              <Suspense fallback={<div>読み込み中...</div>}>
-                <RecommendationList />
-              </Suspense>
-              <Suspense fallback={<div>読み込み中...</div>}>
-                <RecentActivity />
-              </Suspense>
-            </div>
-          </div>
-        </main>
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <Suspense fallback={<div>読み込み中...</div>}>
+            <RecommendationList />
+          </Suspense>
+          <Suspense fallback={<div>読み込み中...</div>}>
+            <RecentActivity />
+          </Suspense>
+        </div>
       </div>
-    </div>
+    </main>
   )
 } 

--- a/src/app/reporters/page.tsx
+++ b/src/app/reporters/page.tsx
@@ -1,50 +1,42 @@
 import { Suspense } from 'react'
-import { Sidebar } from '@/components/layout/sidebar'
-import { Header } from '@/components/layout/header'
 import { ReporterList } from '@/components/reporters/reporter-list'
 import { ReporterFilters } from '@/components/reporters/reporter-filters'
 
 export default function ReportersPage() {
   return (
-    <div className="flex min-h-screen bg-gray-50">
-      <Sidebar />
-      <div className="flex-1 flex flex-col">
-        <Header />
-        <main className="flex-1 lg:pl-64">
-          <div className="px-4 py-6 sm:px-6 lg:px-8">
-            <div className="sm:flex sm:items-center">
-              <div className="sm:flex-auto">
-                <h1 className="text-2xl font-semibold text-gray-900">記者管理</h1>
-                <p className="mt-2 text-sm text-gray-700">
-                  記者の情報を管理し、プレスリリースの送付先を効率的に選択できます
-                </p>
-              </div>
-              <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-                <a
-                  href="/reporters/new"
-                  className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-                >
-                  新規記者追加
-                </a>
-              </div>
-            </div>
-
-            {/* フィルター機能 */}
-            <div className="mt-6">
-              <Suspense fallback={<div>フィルターを読み込み中...</div>}>
-                <ReporterFilters />
-              </Suspense>
-            </div>
-
-            {/* 記者一覧 */}
-            <div className="mt-6">
-              <Suspense fallback={<div>記者一覧を読み込み中...</div>}>
-                <ReporterList />
-              </Suspense>
-            </div>
+    <main className="flex-1 p-6">
+      <div className="max-w-7xl mx-auto">
+        <div className="sm:flex sm:items-center">
+          <div className="sm:flex-auto">
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">記者管理</h1>
+            <p className="mt-2 text-sm text-gray-700 dark:text-gray-300">
+              記者の情報を管理し、プレスリリースの送付先を効率的に選択できます
+            </p>
           </div>
-        </main>
+          <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+            <a
+              href="/reporters/new"
+              className="inline-flex items-center justify-center rounded-md border border-transparent bg-blue-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              新規記者追加
+            </a>
+          </div>
+        </div>
+
+        {/* フィルター機能 */}
+        <div className="mt-6">
+          <Suspense fallback={<div>フィルターを読み込み中...</div>}>
+            <ReporterFilters />
+          </Suspense>
+        </div>
+
+        {/* 記者一覧 */}
+        <div className="mt-6">
+          <Suspense fallback={<div>記者一覧を読み込み中...</div>}>
+            <ReporterList />
+          </Suspense>
+        </div>
       </div>
-    </div>
+    </main>
   )
 } 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -18,7 +18,7 @@ export function Header() {
   }
 
   return (
-    <header className="bg-white border-b border-gray-200 lg:pl-64">
+    <header className="bg-white border-b border-gray-200">
       <div className="flex h-16 items-center justify-between px-4 sm:px-6 lg:px-8">
         <div className="flex items-center">
           <div className="flex-shrink-0">

--- a/src/components/layout/sidebar-wrapper.tsx
+++ b/src/components/layout/sidebar-wrapper.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { usePathname } from 'next/navigation'
+import { Sidebar } from './sidebar'
+
+export function SidebarWrapper() {
+  const pathname = usePathname()
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  if (!mounted) {
+    return null
+  }
+
+  return <Sidebar />
+} 

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -49,7 +49,7 @@ export function Sidebar() {
       </div>
 
       {/* デスクトップ用サイドバー */}
-      <div className="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-64 lg:flex-col">
+      <div className="hidden lg:fixed lg:inset-y-0 lg:flex lg:w-[min(25%,320px)] lg:min-w-[200px] lg:flex-col">
         <div className="flex flex-grow flex-col overflow-y-auto bg-white border-r border-gray-200">
           <SidebarContent pathname={pathname} />
         </div>
@@ -72,7 +72,7 @@ export function Sidebar() {
 function SidebarContent({ pathname }: { pathname: string }) {
   return (
     <div className="flex flex-grow flex-col">
-      <div className="flex flex-shrink-0 items-center px-4 py-6">
+      <div className="flex flex-shrink-0 items-center px-3 lg:px-4 py-6">
         <h1 className="text-xl font-bold text-gray-900">Ko-Ho</h1>
       </div>
       <nav className="flex-1 space-y-1 px-2 pb-4">
@@ -83,7 +83,7 @@ function SidebarContent({ pathname }: { pathname: string }) {
               key={item.name}
               href={item.href}
               className={`
-                group flex items-center px-2 py-2 text-sm font-medium rounded-md
+                group flex items-center px-2 py-2 text-sm font-medium rounded-md whitespace-normal break-words
                 ${isActive
                   ? 'bg-blue-100 text-blue-900'
                   : 'text-gray-600 hover:bg-gray-50 hover:text-gray-900'


### PR DESCRIPTION
 ## 変更内容
     - 各ページ（コンテンツ管理、分析・レポート、記者管理）からサイドバーとヘッダーコンポーネントを削除
     - app/layout.tsxで共通レイアウトを管理するように変更
     - サイドバーの表示幅を調整

## 修正前の問題
     - 各ページで独自のレイアウトを持っていたため、サイドバーとヘッダーが重複して表示される問題があった
     - ページ遷移時にレイアウトが崩れる問題があった

## 修正後の改善点
     - すべてのページで一貫したレイアウトを実現
     - サイドバーの重複表示問題を解消
     - レイアウトの保守性が向上